### PR TITLE
Added friendsandfoes:mauler to the blacklist

### DIFF
--- a/Common/src/main/java/fuzs/respawninganimals/config/ServerConfig.java
+++ b/Common/src/main/java/fuzs/respawninganimals/config/ServerConfig.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 public class ServerConfig implements ConfigCore {
     @Config(name = "animal_blacklist", description = {"Blacklist animals which will never despawn.", ConfigDataSet.CONFIG_DESCRIPTION})
-    List<String> animalBlacklistRaw = Lists.newArrayList("whisperwoods:hirschgeist");
+    List<String> animalBlacklistRaw = Lists.newArrayList("whisperwoods:hirschgeist", "friendsandfoes:mauler");
     @Config(name = "animal_mob_cap", description = "Constant for determining when to stop spawning animals in a world. Normally set to 10, monster constant is 70 for comparison. 18 is chosen to mimic spawning mechanics of the beta era.")
     public int maxAnimalNumber = 18;
     @Config(name = "summoned_mob_persistence", description = "Make all mobs (not just animals) automatically persistent when spawned using the \"/summon\" command, a spawn egg or a dispenser.")


### PR DESCRIPTION
Hello, based on this https://github.com/Faboslav/friends-and-foes/issues/126#issuecomment-1676404060, it would be great to have `friendsandfoes:mauler` on the blacklist by default.